### PR TITLE
Fix heading text in menu

### DIFF
--- a/components/Menu.tsx
+++ b/components/Menu.tsx
@@ -119,7 +119,7 @@ export default function Menu() {
                 className="text-3xl font-bold tracking-tight text-[#252525]"
                 id="join-heading"
               >
-                Découvrer notre menu
+                Découvrez notre menu
               </h2>
               <p className="text-lg text-[#252525]">
                 Pour ceux qui veulent se faire plaisir, venez combler vos désirs


### PR DESCRIPTION
## Summary
- correct French text typo in `Menu.tsx`

## Testing
- `npm run lint` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68426c750ab483298e79119226fb4f78