### PR TITLE
Fix Next.js config warning and peer dep

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -2,7 +2,6 @@
 
 const nextConfig = {
   reactStrictMode: true,
-  swcMinify: true,
   async redirects() {
     return [
       {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@types/react": "19.1.6",
     "@types/react-dom": "19.1.6",
     "autoprefixer": "^10.4.8",
-    "eslint": "8.20.0",
+    "eslint": "^8.57.0",
     "eslint-config-next": "15.3.3",
     "jest": "^29.0.0",
     "postcss": "^8.4.16",


### PR DESCRIPTION
## Summary
- remove deprecated `swcMinify` option
- update ESLint to satisfy `eslint-config-next` peer requirement

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842780f7a1c8329bc73959917d250a7